### PR TITLE
update user liquidity indexing

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -332,7 +332,7 @@ type Bin @entity {
 
   binId: BigInt!
 
-  liquidityProviders: [UserBinLiquidity!]! @derivedFrom(field: "lbPairBinId")
+  liquidityProviders: [String!]!
   liquidityProviderCount: BigInt!
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -332,7 +332,7 @@ type Bin @entity {
 
   binId: BigInt!
 
-  liquidityProviders: [UserBinLiquidity!]! @derivedFrom(field: "lbPairBinId")
+  liquidityProviders: [String!]!
 }
 
 type User @entity {

--- a/schema.graphql
+++ b/schema.graphql
@@ -333,6 +333,7 @@ type Bin @entity {
   binId: BigInt!
 
   liquidityProviders: [String!]!
+  liquidityProviderCount: BigInt!
 }
 
 type User @entity {

--- a/schema.graphql
+++ b/schema.graphql
@@ -332,7 +332,7 @@ type Bin @entity {
 
   binId: BigInt!
 
-  liquidityProviders: [String!]!
+  liquidityProviders: [UserBinLiquidity!]! @derivedFrom(field: "lbPairBinId")
   liquidityProviderCount: BigInt!
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -322,12 +322,17 @@ type LBPair @entity {
 type Bin @entity {
   id: ID! # lbPair address + # + binId
   lbPair: LBPair!
+
   priceX: BigDecimal!
   priceY: BigDecimal!
-  totalSupply: BigInt! 
+
+  totalSupply: BigInt!
   reserveX: BigDecimal!
   reserveY: BigDecimal!
+
   binId: BigInt!
+
+  liquidityProviders: [UserBinLiquidity!]! @derivedFrom(field: "lbPairBinId")
 }
 
 type User @entity {
@@ -434,9 +439,15 @@ type UserBinLiquidity @entity {
   # lbPair address + user + binId
   id: ID!
 
-  binId: BigInt!
+  # lbPair address + user address
   liquidityPosition: LiquidityPosition!
 
+  # lbPair address + binId
+  lbPairBinId: Bin!
+
+  lbPair: LBPair!
+  user: User!
+  binId: BigInt!
   liquidity: BigInt!
 
   block: Int!
@@ -586,11 +597,13 @@ type Transfer @entity {
 
   lbPair: LBPair!
 
-  lbTokenAmount: BigInt!
+  binId: BigInt!
+  amount: BigInt!
 
-  sender: User!
-  recipient: User!
+  sender: Bytes!
+  from: Bytes!
+  to: Bytes!
+
   origin: Bytes!
-
   logIndex: BigInt!
 }

--- a/src/entities/bin.ts
+++ b/src/entities/bin.ts
@@ -1,5 +1,5 @@
 import { BigInt, BigDecimal, Address } from "@graphprotocol/graph-ts";
-import { Bin, LBPair, } from "../../generated/schema";
+import { Bin, LBPair } from "../../generated/schema";
 import { BIG_DECIMAL_ONE, BIG_DECIMAL_ZERO, BIG_INT_ZERO } from "../constants";
 import { loadToken } from "../entities";
 import { getPriceYOfBin } from "../utils";
@@ -20,7 +20,7 @@ export function loadBin(lbPair: LBPair, binId: BigInt): Bin {
     bin.totalSupply = BIG_INT_ZERO;
     bin.priceY = getPriceYOfBin(binId, lbPair.binStep, tokenX, tokenY); // each bin has a determined price
     bin.priceX = BIG_DECIMAL_ONE.div(bin.priceY);
-    bin.liquidityProviders = []
+    bin.liquidityProviders = [];
   }
 
   return bin;

--- a/src/entities/bin.ts
+++ b/src/entities/bin.ts
@@ -21,7 +21,7 @@ export function loadBin(lbPair: LBPair, binId: BigInt): Bin {
     bin.priceY = getPriceYOfBin(binId, lbPair.binStep, tokenX, tokenY); // each bin has a determined price
     bin.priceX = BIG_DECIMAL_ONE.div(bin.priceY);
     bin.liquidityProviders = [];
-    bin.liquidityProviderCount =  BIG_INT_ZERO;
+    bin.liquidityProviderCount = BIG_INT_ZERO;
   }
 
   return bin;

--- a/src/entities/bin.ts
+++ b/src/entities/bin.ts
@@ -20,6 +20,7 @@ export function loadBin(lbPair: LBPair, binId: BigInt): Bin {
     bin.totalSupply = BIG_INT_ZERO;
     bin.priceY = getPriceYOfBin(binId, lbPair.binStep, tokenX, tokenY); // each bin has a determined price
     bin.priceX = BIG_DECIMAL_ONE.div(bin.priceY);
+    bin.liquidityProviders = [];
     bin.liquidityProviderCount = BIG_INT_ZERO;
   }
 

--- a/src/entities/bin.ts
+++ b/src/entities/bin.ts
@@ -20,7 +20,6 @@ export function loadBin(lbPair: LBPair, binId: BigInt): Bin {
     bin.totalSupply = BIG_INT_ZERO;
     bin.priceY = getPriceYOfBin(binId, lbPair.binStep, tokenX, tokenY); // each bin has a determined price
     bin.priceX = BIG_DECIMAL_ONE.div(bin.priceY);
-    bin.liquidityProviders = [];
     bin.liquidityProviderCount = BIG_INT_ZERO;
   }
 

--- a/src/entities/bin.ts
+++ b/src/entities/bin.ts
@@ -1,5 +1,5 @@
 import { BigInt, BigDecimal, Address } from "@graphprotocol/graph-ts";
-import { Bin, LBPair, Token } from "../../generated/schema";
+import { Bin, LBPair, } from "../../generated/schema";
 import { BIG_DECIMAL_ONE, BIG_DECIMAL_ZERO, BIG_INT_ZERO } from "../constants";
 import { loadToken } from "../entities";
 import { getPriceYOfBin } from "../utils";
@@ -20,6 +20,7 @@ export function loadBin(lbPair: LBPair, binId: BigInt): Bin {
     bin.totalSupply = BIG_INT_ZERO;
     bin.priceY = getPriceYOfBin(binId, lbPair.binStep, tokenX, tokenY); // each bin has a determined price
     bin.priceX = BIG_DECIMAL_ONE.div(bin.priceY);
+    bin.liquidityProviders = []
   }
 
   return bin;

--- a/src/entities/bin.ts
+++ b/src/entities/bin.ts
@@ -21,6 +21,7 @@ export function loadBin(lbPair: LBPair, binId: BigInt): Bin {
     bin.priceY = getPriceYOfBin(binId, lbPair.binStep, tokenX, tokenY); // each bin has a determined price
     bin.priceX = BIG_DECIMAL_ONE.div(bin.priceY);
     bin.liquidityProviders = [];
+    bin.liquidityProviderCount =  BIG_INT_ZERO;
   }
 
   return bin;

--- a/src/entities/liquidityPositions.ts
+++ b/src/entities/liquidityPositions.ts
@@ -2,7 +2,7 @@ import { Address, BigInt, ethereum } from "@graphprotocol/graph-ts";
 import { LiquidityPosition, LBPair, User } from "../../generated/schema";
 import { BIG_INT_ZERO, BIG_INT_ONE, ADDRESS_ZERO } from "../constants";
 import { getUserBinLiquidity } from "./userBinLiquidity";
-import { loadUser, loadBin, removeUserBinLiquidity } from "../entities";
+import { loadUser, loadBin } from "../entities";
 
 function getLiquidityPosition(
   lbPair: LBPair,
@@ -62,6 +62,10 @@ export function addLiquidityPosition(
   );
 
   if (userBinLiquidity.liquidity.equals(BIG_INT_ZERO)) {
+    // add user to list of bin's liquidity providers
+    let liquidityProviders = bin.liquidityProviders;
+    liquidityProviders.push(user.id);
+    bin.liquidityProviders = liquidityProviders;
     bin.liquidityProviderCount = bin.liquidityProviderCount.plus(BIG_INT_ONE);
     bin.save();
 
@@ -130,8 +134,22 @@ export function removeLiquidityPosition(
   userBinLiquidity.liquidity = userBinLiquidity.liquidity.minus(liquidity);
 
   if (userBinLiquidity.liquidity.le(BIG_INT_ZERO)) {
-    removeUserBinLiquidity(userBinLiquidity.id);
-    bin.liquidityProviderCount = bin.liquidityProviderCount.minus(BIG_INT_ONE);
+    // remove user from list of bin's liquidity providers
+    let liquidityProviders = bin.liquidityProviders;
+    let index = -1;
+    for (let i = 0; i < liquidityProviders.length; i++) {
+      if (liquidityProviders[i] === user.id) {
+        index = i;
+        break;
+      }
+    }
+    if (index !== -1) {
+      liquidityProviders.splice(index, 1);
+      bin.liquidityProviderCount = bin.liquidityProviderCount.minus(
+        BIG_INT_ONE
+      );
+    }
+    bin.liquidityProviders = liquidityProviders;
     bin.save();
 
     // decrease count of bins with user's liquidityPosition

--- a/src/entities/liquidityPositions.ts
+++ b/src/entities/liquidityPositions.ts
@@ -1,7 +1,10 @@
 import { Address, BigInt, ethereum } from "@graphprotocol/graph-ts";
 import { LiquidityPosition, LBPair } from "../../generated/schema";
-import { BIG_INT_ZERO, BIG_INT_ONE } from "../constants";
-import { getUserBinLiquidity } from "./userBinLiquidity";
+import { BIG_INT_ZERO, BIG_INT_ONE, ADDRESS_ZERO } from "../constants";
+import {
+  getUserBinLiquidity,
+  removeUserBinLiquidity,
+} from "./userBinLiquidity";
 
 function getLiquidityPosition(
   lbPairAddr: Address,
@@ -22,7 +25,7 @@ function getLiquidityPosition(
     liquidityPosition.binsCount = BIG_INT_ZERO;
     liquidityPosition.block = block.number.toI32();
     liquidityPosition.timestamp = block.timestamp.toI32();
-    liquidityPosition.save()
+    liquidityPosition.save();
   }
 
   return liquidityPosition as LiquidityPosition;
@@ -34,7 +37,18 @@ export function addLiquidityPosition(
   binId: BigInt,
   liquidity: BigInt,
   block: ethereum.Block
-): LiquidityPosition {
+): LiquidityPosition | null {
+  // skip if 'user' is zero address (burn transaction)
+  if (user.equals(ADDRESS_ZERO)) {
+    return null;
+  }
+
+  // skip if 'user' is an LBPair address
+  const tryLBPair = LBPair.load(user.toHexString());
+  if (tryLBPair) {
+    return null;
+  }
+
   let liquidityPosition = getLiquidityPosition(lbPairAddr, user, block);
   let userBinLiquidity = getUserBinLiquidity(
     liquidityPosition.id,
@@ -47,7 +61,6 @@ export function addLiquidityPosition(
     liquidityPosition.binsCount = liquidityPosition.binsCount.plus(BIG_INT_ONE);
 
     // increase LBPair liquidityProviderCount if user now has one bin with liquidity
-    // TODO @gaepsuni: investigate if there could be race conditions
     const lbPair = LBPair.load(lbPairAddr.toHexString());
     if (lbPair && liquidityPosition.binsCount.equals(BIG_INT_ONE)) {
       lbPair.liquidityProviderCount = lbPair.liquidityProviderCount.plus(
@@ -77,7 +90,18 @@ export function removeLiquidityPosition(
   binId: BigInt,
   liquidity: BigInt,
   block: ethereum.Block
-): LiquidityPosition {
+): LiquidityPosition | null {
+  // skip if 'user' is zero address (burn transaction)
+  if (user.equals(ADDRESS_ZERO)) {
+    return null;
+  }
+
+  // skip if 'user' is an LBPair address
+  const tryLBPair = LBPair.load(user.toHexString());
+  if (tryLBPair) {
+    return null;
+  }
+
   let liquidityPosition = getLiquidityPosition(lbPairAddr, user, block);
   let userBinLiquidity = getUserBinLiquidity(
     liquidityPosition.id,
@@ -95,7 +119,6 @@ export function removeLiquidityPosition(
     );
 
     // decrease LBPair liquidityProviderCount if user no longer has bins with liquidity
-    // TODO @gaepsuni: investigate if there could be race conditions
     const lbPair = LBPair.load(lbPairAddr.toHexString());
     if (lbPair && liquidityPosition.binsCount.equals(BIG_INT_ZERO)) {
       lbPair.liquidityProviderCount = lbPair.liquidityProviderCount.minus(
@@ -103,6 +126,11 @@ export function removeLiquidityPosition(
       );
       lbPair.save();
     }
+  }
+
+  // remove the user bin liquidity entity is liquidity is now zero
+  if (userBinLiquidity.liquidity.le(BIG_INT_ZERO)) {
+    removeUserBinLiquidity(userBinLiquidity.id);
   }
 
   // update block and timestamp

--- a/src/entities/liquidityPositions.ts
+++ b/src/entities/liquidityPositions.ts
@@ -136,21 +136,15 @@ export function removeLiquidityPosition(
   if (userBinLiquidity.liquidity.le(BIG_INT_ZERO)) {
     // remove user from list of bin's liquidity providers
     let liquidityProviders = bin.liquidityProviders;
-    let index = -1;
-    for (let i = 0; i < liquidityProviders.length; i++) {
-      if (liquidityProviders[i] === user.id) {
-        index = i;
-        break;
-      }
-    }
-    if (index !== -1) {
-      liquidityProviders.splice(index, 1);
+    let idxToRemove = liquidityProviders.indexOf(user.id);
+    if (idxToRemove > -1) {
+      liquidityProviders.splice(idxToRemove, 1);
+      bin.liquidityProviders = liquidityProviders;
       bin.liquidityProviderCount = bin.liquidityProviderCount.minus(
         BIG_INT_ONE
       );
+      bin.save();
     }
-    bin.liquidityProviders = liquidityProviders;
-    bin.save();
 
     // decrease count of bins with user's liquidityPosition
     liquidityPosition.binsCount = liquidityPosition.binsCount.minus(

--- a/src/entities/liquidityPositions.ts
+++ b/src/entities/liquidityPositions.ts
@@ -50,7 +50,7 @@ export function addLiquidityPosition(
   }
 
   const user = loadUser(userAddr);
-  const bin = loadBin(lbPair, binId)
+  const bin = loadBin(lbPair, binId);
 
   let liquidityPosition = getLiquidityPosition(lbPair, user, block);
   let userBinLiquidity = getUserBinLiquidity(
@@ -62,12 +62,11 @@ export function addLiquidityPosition(
   );
 
   if (userBinLiquidity.liquidity.equals(BIG_INT_ZERO)) {
-
     // add user to list of bin's liquidity providers
-    let liquidityProviders = bin.liquidityProviders
-    liquidityProviders.push(user.id)
-    bin.liquidityProviders = liquidityProviders
-    bin.save()
+    let liquidityProviders = bin.liquidityProviders;
+    liquidityProviders.push(user.id);
+    bin.liquidityProviders = liquidityProviders;
+    bin.save();
 
     // increase count of bins user has liquidity
     liquidityPosition.binsCount = liquidityPosition.binsCount.plus(BIG_INT_ONE);
@@ -119,7 +118,7 @@ export function removeLiquidityPosition(
   }
 
   const user = loadUser(userAddr);
-  const bin = loadBin(lbPair, binId)
+  const bin = loadBin(lbPair, binId);
 
   let liquidityPosition = getLiquidityPosition(lbPair, user, block);
   let userBinLiquidity = getUserBinLiquidity(
@@ -133,10 +132,9 @@ export function removeLiquidityPosition(
   // update liquidity
   userBinLiquidity.liquidity = userBinLiquidity.liquidity.minus(liquidity);
 
-  
   if (userBinLiquidity.liquidity.le(BIG_INT_ZERO)) {
     // remove user from list of bin's liquidity providers
-    let liquidityProviders = bin.liquidityProviders
+    let liquidityProviders = bin.liquidityProviders;
     let index = -1;
     for (let i = 0; i < liquidityProviders.length; i++) {
       if (liquidityProviders[i] === user.id) {
@@ -144,11 +142,11 @@ export function removeLiquidityPosition(
         break;
       }
     }
-    if (index !== -1){
+    if (index !== -1) {
       liquidityProviders.splice(index, 1);
     }
-    bin.liquidityProviders = liquidityProviders
-    bin.save()
+    bin.liquidityProviders = liquidityProviders;
+    bin.save();
 
     // decrease count of bins if there is no liquidity remaining
     liquidityPosition.binsCount = liquidityPosition.binsCount.minus(

--- a/src/entities/liquidityPositions.ts
+++ b/src/entities/liquidityPositions.ts
@@ -66,6 +66,9 @@ export function addLiquidityPosition(
     let liquidityProviders = bin.liquidityProviders;
     liquidityProviders.push(user.id);
     bin.liquidityProviders = liquidityProviders;
+    bin.liquidityProviderCount = bin.liquidityProviderCount.plus(
+      BIG_INT_ONE
+    );
     bin.save();
 
     // increase count of bins user has liquidity
@@ -144,6 +147,9 @@ export function removeLiquidityPosition(
     }
     if (index !== -1) {
       liquidityProviders.splice(index, 1);
+      bin.liquidityProviderCount = bin.liquidityProviderCount.minus(
+        BIG_INT_ONE
+      );
     }
     bin.liquidityProviders = liquidityProviders;
     bin.save();

--- a/src/entities/liquidityPositions.ts
+++ b/src/entities/liquidityPositions.ts
@@ -33,7 +33,7 @@ export function addLiquidityPosition(
   liquidity: BigInt,
   block: ethereum.Block
 ): LiquidityPosition | null {
-  // skip if 'userAddr' is zero address (burn transaction)
+  // skip if 'userAddr' is zero address (mint transaction)
   if (userAddr.equals(ADDRESS_ZERO)) {
     return null;
   }
@@ -66,9 +66,7 @@ export function addLiquidityPosition(
     let liquidityProviders = bin.liquidityProviders;
     liquidityProviders.push(user.id);
     bin.liquidityProviders = liquidityProviders;
-    bin.liquidityProviderCount = bin.liquidityProviderCount.plus(
-      BIG_INT_ONE
-    );
+    bin.liquidityProviderCount = bin.liquidityProviderCount.plus(BIG_INT_ONE);
     bin.save();
 
     // increase count of bins user has liquidity
@@ -154,7 +152,7 @@ export function removeLiquidityPosition(
     bin.liquidityProviders = liquidityProviders;
     bin.save();
 
-    // decrease count of bins if there is no liquidity remaining
+    // decrease count of bins with user's liquidityPosition
     liquidityPosition.binsCount = liquidityPosition.binsCount.minus(
       BIG_INT_ONE
     );

--- a/src/entities/userBinLiquidity.ts
+++ b/src/entities/userBinLiquidity.ts
@@ -1,4 +1,4 @@
-import { Address, BigInt, ethereum, store } from "@graphprotocol/graph-ts";
+import { BigInt, ethereum, store } from "@graphprotocol/graph-ts";
 import { UserBinLiquidity, LBPair, User } from "../../generated/schema";
 import { BIG_INT_ZERO } from "../constants";
 

--- a/src/entities/userBinLiquidity.ts
+++ b/src/entities/userBinLiquidity.ts
@@ -1,4 +1,4 @@
-import { BigInt, ethereum } from "@graphprotocol/graph-ts";
+import { BigInt, ethereum, store } from "@graphprotocol/graph-ts";
 import { UserBinLiquidity } from "../../generated/schema";
 import { BIG_INT_ZERO } from "../constants";
 
@@ -18,8 +18,12 @@ export function getUserBinLiquidity(
     userBinLiquidity.liquidity = BIG_INT_ZERO;
     userBinLiquidity.block = block.number.toI32();
     userBinLiquidity.timestamp = block.timestamp.toI32();
-    userBinLiquidity.save()
+    userBinLiquidity.save();
   }
 
   return userBinLiquidity as UserBinLiquidity;
+}
+
+export function removeUserBinLiquidity(id: string): void {
+  store.remove("UserBinLiquidity", id);
 }

--- a/src/entities/userBinLiquidity.ts
+++ b/src/entities/userBinLiquidity.ts
@@ -1,19 +1,25 @@
-import { BigInt, ethereum, store } from "@graphprotocol/graph-ts";
-import { UserBinLiquidity } from "../../generated/schema";
+import { Address, BigInt, ethereum, store } from "@graphprotocol/graph-ts";
+import { UserBinLiquidity, LBPair, User } from "../../generated/schema";
 import { BIG_INT_ZERO } from "../constants";
 
 export function getUserBinLiquidity(
   liquidityPositionsId: string,
+  lbPair: LBPair,
+  user: User,
   binId: BigInt,
   block: ethereum.Block
 ): UserBinLiquidity {
   const id = liquidityPositionsId.concat("-").concat(binId.toString());
+  const lbPairBinId = lbPair.id.concat("#").concat(binId.toString());
 
   let userBinLiquidity = UserBinLiquidity.load(id);
 
   if (!userBinLiquidity) {
     userBinLiquidity = new UserBinLiquidity(id);
+    userBinLiquidity.lbPair = lbPair.id;
+    userBinLiquidity.user = user.id;
     userBinLiquidity.binId = binId;
+    userBinLiquidity.lbPairBinId = lbPairBinId;
     userBinLiquidity.liquidityPosition = liquidityPositionsId;
     userBinLiquidity.liquidity = BIG_INT_ZERO;
     userBinLiquidity.block = block.number.toI32();

--- a/src/lbPair.ts
+++ b/src/lbPair.ts
@@ -944,9 +944,6 @@ export function handleTransferSingle(event: TransferSingle): void {
   lbFactory.txCount = lbFactory.txCount.plus(BIG_INT_ONE);
   lbFactory.save();
 
-  const sender = loadUser(event.params.from);
-  const recipient = loadUser(event.params.to);
-
   loadTraderJoeHourData(event.block.timestamp, true);
   loadTraderJoeDayData(event.block.timestamp, true);
 
@@ -990,7 +987,7 @@ export function handleTransferSingle(event: TransferSingle): void {
       BIG_DECIMAL_ZERO,
       BIG_DECIMAL_ZERO,
       BIG_INT_ZERO,
-      event.params.amount, // burned
+      event.params.amount // burned
     );
   }
 
@@ -1008,9 +1005,11 @@ export function handleTransferSingle(event: TransferSingle): void {
   transfer.transaction = transaction.id;
   transfer.timestamp = event.block.timestamp.toI32();
   transfer.lbPair = lbPair.id;
-  transfer.lbTokenAmount = event.params.amount;
-  transfer.sender = sender.id;
-  transfer.recipient = recipient.id;
+  transfer.binId = event.params.id;
+  transfer.amount = event.params.amount;
+  transfer.sender = event.params.sender;
+  transfer.from = event.params.from;
+  transfer.to = event.params.to;
   transfer.origin = event.transaction.from;
   transfer.logIndex = event.logIndex;
 
@@ -1042,28 +1041,28 @@ export function handleTransferBatch(event: TransferBatch): void {
     // mint: increase bin totalSupply
     if (ADDRESS_ZERO.equals(event.params.from)) {
       trackBin(
-          lbPair,
-          event.params.ids[i],
-          BIG_DECIMAL_ZERO,
-          BIG_DECIMAL_ZERO,
-          BIG_DECIMAL_ZERO,
-          BIG_DECIMAL_ZERO,
-          event.params.amounts[i], // minted
-          BIG_INT_ZERO
+        lbPair,
+        event.params.ids[i],
+        BIG_DECIMAL_ZERO,
+        BIG_DECIMAL_ZERO,
+        BIG_DECIMAL_ZERO,
+        BIG_DECIMAL_ZERO,
+        event.params.amounts[i], // minted
+        BIG_INT_ZERO
       );
     }
 
     // burn: decrease bin totalSupply
     if (ADDRESS_ZERO.equals(event.params.to)) {
       trackBin(
-          lbPair,
-          event.params.ids[i],
-          BIG_DECIMAL_ZERO,
-          BIG_DECIMAL_ZERO,
-          BIG_DECIMAL_ZERO,
-          BIG_DECIMAL_ZERO,
-          BIG_INT_ZERO,
-          event.params.amounts[i], // burned
+        lbPair,
+        event.params.ids[i],
+        BIG_DECIMAL_ZERO,
+        BIG_DECIMAL_ZERO,
+        BIG_DECIMAL_ZERO,
+        BIG_DECIMAL_ZERO,
+        BIG_INT_ZERO,
+        event.params.amounts[i] // burned
       );
     }
   }


### PR DESCRIPTION
This PR makes a couple of updates in prep for indexing user accrued fees:

- skip creating User, LiquidityPosition, and UserBinLiquidity entities for zero and LBPair addresses
- add `liquidityProviderCount` and `liquidityProviders` fields on the `Bin` entity to quickly query the bin's LPs
- add `user` and `lbPair` fields to UserBinLiquidity entity
- fix `Transfer` transaction entity