### PR TITLE
index mint/burn transactions

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -606,11 +606,17 @@ type Collect @entity {
   logIndex: BigInt!
 }
 
+# indexes both TransferSingle and TransferBatch events
 type Transfer @entity {
-  # transaction hash + "#" + index in transfer Transaction array
+  # transaction hash + "#" + index in transfer Transaction array + "#" + (optional: TransferBatch index)
   id: ID!
   transaction: Transaction!
   timestamp: Int!
+
+  isBatch: Boolean!
+  batchIndex: Int # optional only for TransferBatch event
+  isMint: Boolean!
+  isBurn: Boolean!
 
   lbPair: LBPair!
 


### PR DESCRIPTION
This PR updates the `Transfer` entity to index both TransferSingle and TransferBatch events.  `isMint` and `isBurn` fields are also added to easily filter the mint and burn transactions