### PR TITLE
add accruedFeesL to user fee data

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -480,9 +480,11 @@ type UserFeesData @entity {
 
   accruedFeesX: BigDecimal!
   accruedFeesY: BigDecimal!
+  accruedFeesL: BigDecimal!
 
   collectedFeesX: BigDecimal!
   collectedFeesY: BigDecimal!
+  collectedFeesL: BigDecimal!
 }
 
 type UserFeesHourData @entity {
@@ -496,9 +498,11 @@ type UserFeesHourData @entity {
 
   accruedFeesX: BigDecimal!
   accruedFeesY: BigDecimal!
+  accruedFeesL: BigDecimal!
 
   collectedFeesX: BigDecimal!
   collectedFeesY: BigDecimal!
+  collectedFeesL: BigDecimal!
 }
 
 type Transaction @entity {

--- a/schema.graphql
+++ b/schema.graphql
@@ -484,7 +484,6 @@ type UserFeesData @entity {
 
   collectedFeesX: BigDecimal!
   collectedFeesY: BigDecimal!
-  collectedFeesL: BigDecimal!
 }
 
 type UserFeesHourData @entity {
@@ -502,7 +501,6 @@ type UserFeesHourData @entity {
 
   collectedFeesX: BigDecimal!
   collectedFeesY: BigDecimal!
-  collectedFeesL: BigDecimal!
 }
 
 type Transaction @entity {

--- a/src/entities/userFeesData.ts
+++ b/src/entities/userFeesData.ts
@@ -20,8 +20,10 @@ export function loadUserFeesData(lbPair: LBPair, user: User): UserFeesData {
     userFeesData.lbPair = lbPair.id;
     userFeesData.accruedFeesX = BIG_DECIMAL_ZERO;
     userFeesData.accruedFeesY = BIG_DECIMAL_ZERO;
+    userFeesData.accruedFeesL = BIG_DECIMAL_ZERO;
     userFeesData.collectedFeesX = BIG_DECIMAL_ZERO;
     userFeesData.collectedFeesY = BIG_DECIMAL_ZERO;
+    userFeesData.collectedFeesL = BIG_DECIMAL_ZERO;
     userFeesData.save();
   }
 
@@ -52,8 +54,10 @@ export function loadUserFeesHourData(
     userFeesHourData.lbPair = lbPair.id;
     userFeesHourData.accruedFeesX = BIG_DECIMAL_ZERO;
     userFeesHourData.accruedFeesY = BIG_DECIMAL_ZERO;
+    userFeesHourData.accruedFeesL = BIG_DECIMAL_ZERO;
     userFeesHourData.collectedFeesX = BIG_DECIMAL_ZERO;
     userFeesHourData.collectedFeesY = BIG_DECIMAL_ZERO;
+    userFeesHourData.collectedFeesL = BIG_DECIMAL_ZERO;
     userFeesHourData.save();
   }
 

--- a/src/entities/userFeesData.ts
+++ b/src/entities/userFeesData.ts
@@ -112,9 +112,21 @@ export function updateUserAccruedFeesDataSingleToken(
       userFeesHourData.accruedFeesX = userFeesHourData.accruedFeesX.plus(
         providerFee
       );
+
+      userFeesData.accruedFeesL = userFeesData.accruedFeesL.plus(
+        providerFee.times(bin.priceY)
+      );
+      userFeesHourData.accruedFeesL = userFeesHourData.accruedFeesL.plus(
+        providerFee.times(bin.priceY)
+      );
     } else {
       userFeesData.accruedFeesY = userFeesData.accruedFeesY.plus(providerFee);
       userFeesHourData.accruedFeesY = userFeesHourData.accruedFeesY.plus(
+        providerFee
+      );
+
+      userFeesData.accruedFeesL = userFeesData.accruedFeesL.plus(providerFee);
+      userFeesHourData.accruedFeesL = userFeesHourData.accruedFeesL.plus(
         providerFee
       );
     }
@@ -181,6 +193,13 @@ export function updateUserAccruedFeesDataBothTokens(
     userFeesHourData.accruedFeesY = userFeesHourData.accruedFeesY.plus(
       providerFeeY
     );
+
+    userFeesData.accruedFeesL = userFeesData.accruedFeesL
+      .plus(providerFeeY)
+      .plus(providerFeeX.times(bin.priceY));
+    userFeesHourData.accruedFeesL = userFeesHourData.accruedFeesL
+      .plus(providerFeeY)
+      .plus(providerFeeX.times(bin.priceY));
 
     userFeesData.save();
     userFeesHourData.save();

--- a/src/entities/userFeesData.ts
+++ b/src/entities/userFeesData.ts
@@ -23,7 +23,6 @@ export function loadUserFeesData(lbPair: LBPair, user: User): UserFeesData {
     userFeesData.accruedFeesL = BIG_DECIMAL_ZERO;
     userFeesData.collectedFeesX = BIG_DECIMAL_ZERO;
     userFeesData.collectedFeesY = BIG_DECIMAL_ZERO;
-    userFeesData.collectedFeesL = BIG_DECIMAL_ZERO;
     userFeesData.save();
   }
 
@@ -57,7 +56,6 @@ export function loadUserFeesHourData(
     userFeesHourData.accruedFeesL = BIG_DECIMAL_ZERO;
     userFeesHourData.collectedFeesX = BIG_DECIMAL_ZERO;
     userFeesHourData.collectedFeesY = BIG_DECIMAL_ZERO;
-    userFeesHourData.collectedFeesL = BIG_DECIMAL_ZERO;
     userFeesHourData.save();
   }
 


### PR DESCRIPTION
This PR updates the UserFeeData and UserFeeHourData entities to track `accruedFeesL`. This field is needed for better comparison of user accrued fees between bins because price of X in Y terms varies across all bins. 